### PR TITLE
Fix unresponsive login and register buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
                 <button id="registerTab" class="flex-1 py-2 px-4 bg-gray-200 text-gray-700 rounded-r-lg font-medium">Register</button>
             </div>
             
-            <form id="authForm">
+            <form id="authForm" novalidate>
                 <div class="mb-4">
                     <label class="block text-gray-700 text-sm font-medium mb-2">Email</label>
                     <input type="email" id="email" class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" required>
@@ -1420,20 +1420,26 @@
             // Custom profile picture uploads
                 
 
-            // Sync modal
-            document.getElementById('syncSettingsBtn').addEventListener('click', () => {
-                document.getElementById('syncUrlInput').value = syncUrl || '';
-                document.getElementById('syncModal').classList.remove('hidden');
-            });
-            document.getElementById('closeSyncModal').addEventListener('click', () => document.getElementById('syncModal').classList.add('hidden'));
-            document.getElementById('saveSyncUrl').addEventListener('click', () => {
+            // Sync modal (guard missing button)
+            const syncBtn = document.getElementById('syncSettingsBtn');
+            if (syncBtn) {
+                syncBtn.addEventListener('click', () => {
+                    document.getElementById('syncUrlInput').value = syncUrl || '';
+                    document.getElementById('syncModal').classList.remove('hidden');
+                });
+            }
+            const closeSync = document.getElementById('closeSyncModal');
+            if (closeSync) closeSync.addEventListener('click', () => document.getElementById('syncModal').classList.add('hidden'));
+            const saveSync = document.getElementById('saveSyncUrl');
+            if (saveSync) saveSync.addEventListener('click', () => {
                 const url = document.getElementById('syncUrlInput').value;
                 setSyncUrl(url);
                 document.getElementById('syncModal').classList.add('hidden');
                 showNotification('Sync URL saved', 'success');
                 syncPullAndMaybeUpdate();
             });
-            document.getElementById('clearSyncUrl').addEventListener('click', () => {
+            const clearSync = document.getElementById('clearSyncUrl');
+            if (clearSync) clearSync.addEventListener('click', () => {
                 setSyncUrl(null);
                 document.getElementById('syncModal').classList.add('hidden');
                 showNotification('Sync disabled', 'info');

--- a/index.html
+++ b/index.html
@@ -1363,7 +1363,9 @@
             
             // Toggle eliminated (panel removed — guard)
             const toggleEliminatedBtn = document.getElementById('toggleEliminated');
-            if (toggleEliminatedBtn) toggleEliminatedBtn.addEventListener('click', toggleEliminatedPlayers);
+            if (toggleEliminatedBtn && typeof toggleEliminatedPlayers === 'function') {
+                toggleEliminatedBtn.addEventListener('click', toggleEliminatedPlayers);
+            }
             
             // View picks modal
             document.getElementById('viewPicksCard').addEventListener('click', openPicksModal);


### PR DESCRIPTION
Add `novalidate` to the auth form and guard sync modal event listeners to fix unresponsive login/register buttons.

The login/register buttons were not responding due to HTML5 form validation preventing submission and potential JavaScript errors from missing elements halting event listener setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-f9d8a9dd-d89b-4c70-9598-35dfad83b04c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f9d8a9dd-d89b-4c70-9598-35dfad83b04c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

